### PR TITLE
Added SwitchToTrial method to ExperimentConfig

### DIFF
--- a/NScientist.Tests/ExperimentTests.cs
+++ b/NScientist.Tests/ExperimentTests.cs
@@ -109,8 +109,8 @@ namespace NScientist.Tests
 				.Publish(ToThis)
 				.Run();
 
-			_result.Control.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(20));
-			_result.Trial.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(10));
+			_result.Control.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(19));
+			_result.Trial.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(9));
 		}
 
 		[Fact]
@@ -361,7 +361,45 @@ namespace NScientist.Tests
 			publisher.Results.Matched.ShouldBe(true);
 		}
 
-		private class TestPublisher : IPublisher
+        [Fact]
+        public void When_switch_to_trial_is_false()
+        {
+            var result = Experiment
+                .On(() => true)
+                .Try(() => false)
+                .SwitchToTrial(() => false)
+                .Run();
+
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void When_switch_to_trial_is_true_and_only_one_trial_set()
+        {
+            var result = Experiment
+                .On(() => true)
+                .Try(() => false)
+                .SwitchToTrial(() => true)
+                .Publish((r) => { string str = null; str.ToString(); })
+                .Run();
+
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void When_switch_to_trial_is_true_and_more_than_one_trial_set()
+        {
+            var result = Experiment
+                .On(() => true)
+                .Try(() => false)
+                .Try(() => false)
+                .SwitchToTrial(() => true)
+                .Run();
+
+            result.ShouldBeTrue();
+        }
+
+        private class TestPublisher : IPublisher
 		{
 			public Results Results { get; private set; }
 

--- a/NScientist/ExperimentConfig.cs
+++ b/NScientist/ExperimentConfig.cs
@@ -19,8 +19,9 @@ namespace NScientist
 
 		private readonly Trial<TResult> _control;
 		private readonly List<Trial<TResult>> _trials;
+	    private Func<bool> _switchToTrial;
 
-		public ExperimentConfig(Func<TResult> action)
+	    public ExperimentConfig(Func<TResult> action)
 		{
 			_control = new Trial<TResult>(this, action) { TrialName = "Unnamed Experiment" };
 			_trials = new List<Trial<TResult>>();
@@ -34,7 +35,8 @@ namespace NScientist
 			_createContext = () => new Dictionary<object, object>();
 			_throwMismatches = false;
 			_parallel = false;
-		}
+            _switchToTrial = () => false;
+        }
 
 		public ExperimentConfig<TResult> Try(Func<TResult> action)
 		{
@@ -106,9 +108,21 @@ namespace NScientist
 			return this;
 		}
 
-		public TResult Run()
+        public ExperimentConfig<TResult> SwitchToTrial(Func<bool> switchToTrial)
+        {
+            _switchToTrial = switchToTrial;
+            return this;
+        }
+
+        public TResult Run()
 		{
-			var enabled = _isEnabled();
+            //if switchToTrial and we're only running one trial, use that trial instead of the control
+            //if more than one trial is set, we can't know which trial to switch to so continue as normal experiment
+            var shouldSwitchToTrial = _switchToTrial();
+            if (shouldSwitchToTrial && _trials.Count == 1)
+                return _trials.Single().Execute();
+
+            var enabled = _isEnabled();
 
 			if (enabled == false)
 				return _control.Execute();

--- a/NScientist/NScientist.csproj
+++ b/NScientist/NScientist.csproj
@@ -47,7 +47,6 @@
     <Compile Include="MismatchException.cs" />
     <Compile Include="Observation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Properties\AssemblyVersion.cs" />
     <Compile Include="Results.cs" />
     <Compile Include="Trial.cs" />
   </ItemGroup>


### PR DESCRIPTION
#1

Added SwitchToTrial method in the ExperimentConfig to switch to the trial function instead of the control. This is determined by some user defined function. This is useful for feature toggled systems.

If the experiment includes more than one trial, the experiment can't know which trial value to use so it will run normally, regardless of the SwitchToTrial value.
